### PR TITLE
Added collider with basic interactions

### DIFF
--- a/src/game/collider.ts
+++ b/src/game/collider.ts
@@ -1,0 +1,63 @@
+import { PolyObject } from './objects/polyObject';
+
+export enum Groups {
+    asteroids,
+    ship,
+    shots,
+    missiles,
+    center,
+}
+
+interface Collider {
+    addRule: (g1: Groups, g2: Groups) => void;
+    addObjectToGroup: (obj: PolyObject, group: Groups) => void;
+    removeObjectFromGroup: (obj: PolyObject, group: Groups) => void;
+    update: () => void;
+}
+
+type ColliderGroups = Record<Groups, Set<PolyObject>>;
+
+export class PolyCollider implements Collider {
+    private rules: Set<[Groups, Groups]>;
+    private groups: ColliderGroups;
+
+    constructor() {
+        this.rules = new Set();
+        this.groups = {
+            [Groups.asteroids]: new Set(),
+            [Groups.ship]: new Set(),
+            [Groups.shots]: new Set(),
+            [Groups.missiles]: new Set(),
+            [Groups.center]: new Set(),
+        };
+    }
+
+    addRule = (g1: Groups, g2: Groups): void => {
+        this.rules.add([g1, g2]);
+    };
+
+    addObjectToGroup = (obj: PolyObject, group: Groups): void => {
+        this.groups[group].add(obj);
+    };
+
+    removeObjectFromGroup = (obj: PolyObject, group: Groups): void => {
+        this.groups[group].delete(obj);
+    };
+
+    update = (): void => {
+        this.rules.forEach(([g1, g2]) => {
+            this.groups[g1].forEach((o1) => {
+                this.groups[g2].forEach((o2) => {
+                    if (polyObjectsCollide(o1, o2)) {
+                        o1.onCollide?.(o2);
+                        o2.onCollide?.(o1);
+                    }
+                });
+            });
+        });
+    };
+}
+
+const polyObjectsCollide = (o1: PolyObject, o2: PolyObject): boolean => {
+    return o1.hitbox.intersects(o2.hitbox);
+};

--- a/src/game/objects/asteroid/asteroid.ts
+++ b/src/game/objects/asteroid/asteroid.ts
@@ -52,7 +52,6 @@ export class Asteroid implements PolyObject {
         this.hitbox.update();
 
         if (tooFarFromCenter(this.mesh.position)) {
-            console.log('dropping asteroid!');
             this.drop();
         }
     };

--- a/src/game/objects/asteroid/asteroid.ts
+++ b/src/game/objects/asteroid/asteroid.ts
@@ -5,9 +5,12 @@ import { PolyClock } from '../../clock/PolyClock';
 import { tooFarFromCenter } from '../../utils';
 import { DropFunction } from '../manager';
 import { AsteroidMeshFactory } from './meshFactory';
+import { PolyHitbox } from '../hitbox';
 
 export class Asteroid implements PolyObject {
     public mesh: THREE.Object3D;
+    public hitbox: PolyHitbox;
+
     private normal: Vector3;
     private drop: () => void;
     private angularVelocity: number;
@@ -16,6 +19,8 @@ export class Asteroid implements PolyObject {
 
     constructor(meshFactory: AsteroidMeshFactory, drop: DropFunction<Asteroid>) {
         this.mesh = meshFactory.buildMesh();
+        this.hitbox = new PolyHitbox(this.mesh, meshFactory.getHitboxGeometry());
+
         this.normal = new Vector3(0, 1, 0);
 
         this.angularVelocity = 1;
@@ -29,6 +34,10 @@ export class Asteroid implements PolyObject {
         this.normal = normal;
     };
 
+    public onCollide = (who: PolyObject): void => {
+        this.drop();
+    };
+
     public update = (): void => {
         const { delta } = this.clock;
         // Rotation
@@ -39,6 +48,8 @@ export class Asteroid implements PolyObject {
         const currentLength = this.mesh.position.length();
         const lengthOffset = this.radialVelocity * delta;
         this.mesh.position.setLength(currentLength + lengthOffset);
+
+        this.hitbox.update();
 
         if (tooFarFromCenter(this.mesh.position)) {
             console.log('dropping asteroid!');

--- a/src/game/objects/asteroid/manager.ts
+++ b/src/game/objects/asteroid/manager.ts
@@ -5,6 +5,7 @@ import { repeat, getDumpster, randomUnitVector, assertExists, getOne } from '../
 import { ASTEROIDS_IN_SCENE, MIN_RADIUS } from '../../constants';
 import { Manager } from '../manager';
 import { AsteroidMeshFactory } from './meshFactory';
+import { PolyCollider, Groups } from '../../collider';
 
 export class AsteroidManager implements Manager<Asteroid> {
     private idleObjects: Set<Asteroid>;
@@ -12,7 +13,7 @@ export class AsteroidManager implements Manager<Asteroid> {
     private scene: PolyScene;
     private meshFactory: AsteroidMeshFactory;
 
-    constructor() {
+    constructor(private collider: PolyCollider) {
         this.idleObjects = new Set();
         this.liveObjects = new Set();
         this.scene = PolyScene.getInstance();
@@ -41,12 +42,16 @@ export class AsteroidManager implements Manager<Asteroid> {
         this.liveObjects.add(objectToSpawn);
 
         objectToSpawn.spawn(position, normal);
+
+        this.collider.addObjectToGroup(objectToSpawn, Groups.asteroids);
     };
 
     public drop = (objectToDelete: Asteroid) => {
         objectToDelete.mesh.position.copy(getDumpster());
         this.liveObjects.delete(objectToDelete);
         this.idleObjects.add(objectToDelete);
+
+        this.collider.removeObjectFromGroup(objectToDelete, Groups.asteroids);
     };
 
     public update = () => {

--- a/src/game/objects/asteroid/meshFactory.ts
+++ b/src/game/objects/asteroid/meshFactory.ts
@@ -3,18 +3,23 @@ import { MeshFactory } from '../meshFactory';
 
 export class AsteroidMeshFactory implements MeshFactory {
     private mesh: THREE.Mesh;
+    private hitboxGeometry: THREE.Geometry | THREE.BufferGeometry;
 
     constructor() {
-        const geometry = new THREE.DodecahedronBufferGeometry(1);
+        this.hitboxGeometry = new THREE.DodecahedronBufferGeometry(1);
         const material = new THREE.MeshBasicMaterial({
             color: 0x2bfa2b,
             wireframe: true,
         });
 
-        this.mesh = new THREE.Mesh(geometry, material);
+        this.mesh = new THREE.Mesh(this.hitboxGeometry, material);
     }
 
     public buildMesh = (): THREE.Mesh => {
         return this.mesh.clone();
+    };
+
+    public getHitboxGeometry = (): THREE.Geometry | THREE.BufferGeometry => {
+        return this.hitboxGeometry.clone();
     };
 }

--- a/src/game/objects/center.ts
+++ b/src/game/objects/center.ts
@@ -1,9 +1,11 @@
 import * as THREE from 'three';
 import { PolyObject } from './polyObject';
 import { CENTER_RADIUS } from '../constants';
+import { PolyHitbox } from './hitbox';
 
 export class Center implements PolyObject {
     public mesh: THREE.Group;
+    public hitbox: PolyHitbox;
 
     constructor() {
         this.mesh = new THREE.Group();
@@ -16,5 +18,7 @@ export class Center implements PolyObject {
 
         const centerMesh = new THREE.Mesh(geometry, material);
         this.mesh.add(centerMesh);
+
+        this.hitbox = new PolyHitbox(this.mesh, geometry);
     }
 }

--- a/src/game/objects/followMissile/followMissile.ts
+++ b/src/game/objects/followMissile/followMissile.ts
@@ -4,9 +4,12 @@ import { PolyClock } from '../../clock/PolyClock';
 import { randomUnitVector, MathUtils, tooFarFromCenter } from '../../utils';
 import { MissileMeshFactory } from './meshFactory';
 import { DropFunction } from '../manager';
+import { PolyHitbox } from '../hitbox';
 
 export class FollowMissile implements PolyObject {
     public mesh: THREE.Object3D;
+    public hitbox: PolyHitbox;
+
     private direction: THREE.Vector3;
     private clock: PolyClock;
     private drop: () => void;
@@ -27,6 +30,8 @@ export class FollowMissile implements PolyObject {
         this.mesh = meshFactory.buildMesh();
         this.direction = randomUnitVector();
 
+        this.hitbox = new PolyHitbox(this.mesh, meshFactory.getHitboxGeometry());
+
         this.drop = () => drop(this);
     }
 
@@ -43,9 +48,15 @@ export class FollowMissile implements PolyObject {
         this.updatePosition();
         this.updateFlames();
 
+        this.hitbox.update();
+
         if (tooFarFromCenter(this.mesh.position)) {
             this.drop();
         }
+    };
+
+    public onCollide = (who: PolyObject): void => {
+        this.drop();
     };
 
     private updateRotation = (): void => {

--- a/src/game/objects/followMissile/manager.ts
+++ b/src/game/objects/followMissile/manager.ts
@@ -12,6 +12,7 @@ import {
 import { MISSILES_IN_SCENE } from '../../constants';
 import { Manager } from '../manager';
 import { MissileMeshFactory } from './meshFactory';
+import { PolyCollider, Groups } from '../../collider';
 
 export class FollowMissileManager implements Manager<FollowMissile> {
     private idleObjects: Set<FollowMissile>;
@@ -19,7 +20,7 @@ export class FollowMissileManager implements Manager<FollowMissile> {
     private scene: PolyScene;
     private meshFactory: MissileMeshFactory;
 
-    constructor(followedObject: THREE.Object3D) {
+    constructor(followedObject: THREE.Object3D, private collider: PolyCollider) {
         this.idleObjects = new Set();
         this.liveObjects = new Set();
         this.scene = PolyScene.getInstance();
@@ -48,12 +49,16 @@ export class FollowMissileManager implements Manager<FollowMissile> {
         this.liveObjects.add(objectToSpawn);
 
         objectToSpawn.spawn(position, direction);
+
+        this.collider.addObjectToGroup(objectToSpawn, Groups.missiles);
     };
 
     public drop = (objectToDelete: FollowMissile) => {
         objectToDelete.mesh.position.copy(getDumpster());
         this.liveObjects.delete(objectToDelete);
         this.idleObjects.add(objectToDelete);
+
+        this.collider.removeObjectFromGroup(objectToDelete, Groups.missiles);
     };
 
     public update = () => {

--- a/src/game/objects/followMissile/meshFactory.ts
+++ b/src/game/objects/followMissile/meshFactory.ts
@@ -3,9 +3,10 @@ import { MeshFactory } from '../meshFactory';
 
 export class MissileMeshFactory implements MeshFactory {
     private mesh: THREE.Mesh;
+    private hitboxGeometry: THREE.Geometry | THREE.BufferGeometry;
 
     constructor() {
-        const misilGeometry = new THREE.CylinderBufferGeometry(0.2, 0.4, 1, 6, 1);
+        this.hitboxGeometry = new THREE.CylinderBufferGeometry(0.2, 0.4, 1, 6, 1);
         const misilMaterial = new THREE.MeshBasicMaterial({
             wireframe: true,
             color: 0xffffff,
@@ -30,12 +31,16 @@ export class MissileMeshFactory implements MeshFactory {
         lightFire.rotateX(Math.PI);
         darkFire.rotateX(Math.PI);
 
-        this.mesh = new THREE.Mesh(misilGeometry, misilMaterial);
+        this.mesh = new THREE.Mesh(this.hitboxGeometry, misilMaterial);
         this.mesh.add(lightFire);
         this.mesh.add(darkFire);
     }
 
     public buildMesh = (): THREE.Mesh => {
         return this.mesh.clone();
+    };
+
+    public getHitboxGeometry = (): THREE.Geometry | THREE.BufferGeometry => {
+        return this.hitboxGeometry.clone();
     };
 }

--- a/src/game/objects/hitbox.ts
+++ b/src/game/objects/hitbox.ts
@@ -1,0 +1,49 @@
+import * as THREE from 'three';
+import { assertExists, isNil } from '../utils';
+import { PolyScene } from '../scene/PolyScene';
+
+export class PolyHitbox {
+    public shape: THREE.Sphere;
+    private hitboxDebug: THREE.Mesh | null;
+
+    constructor(
+        private followedObject: THREE.Object3D,
+        geometry: THREE.Geometry | THREE.BufferGeometry
+    ) {
+        const internalGeometry = geometry.clone();
+        internalGeometry.computeBoundingSphere();
+        this.shape = assertExists(internalGeometry.boundingSphere);
+
+        this.hitboxDebug = null;
+
+        this.update();
+    }
+
+    debug = (): void => {
+        const scene = PolyScene.getInstance();
+
+        const geometry = new THREE.SphereBufferGeometry(this.shape.radius, 8, 6);
+        const material = new THREE.MeshBasicMaterial({
+            color: 0x324ca8,
+            wireframe: true,
+        });
+
+        this.hitboxDebug = new THREE.Mesh(geometry, material);
+
+        scene.add(this.hitboxDebug);
+
+        this.update();
+    };
+
+    update = (): void => {
+        const objectPosition = this.followedObject.position.clone();
+        this.shape.center.copy(objectPosition);
+        if (!isNil(this.hitboxDebug)) {
+            this.hitboxDebug.position.copy(objectPosition);
+        }
+    };
+
+    intersects = (hitbox: PolyHitbox): boolean => {
+        return this.shape.intersectsSphere(hitbox.shape);
+    };
+}

--- a/src/game/objects/meshFactory.ts
+++ b/src/game/objects/meshFactory.ts
@@ -1,3 +1,4 @@
 export interface MeshFactory {
     buildMesh: () => void;
+    getHitboxGeometry: () => THREE.Geometry | THREE.BufferGeometry;
 }

--- a/src/game/objects/polyObject.ts
+++ b/src/game/objects/polyObject.ts
@@ -1,6 +1,9 @@
 import * as THREE from 'three';
+import { PolyHitbox } from './hitbox';
 
 export interface PolyObject {
     mesh: THREE.Object3D;
     update?: () => void;
+    hitbox: PolyHitbox;
+    onCollide?: (who: PolyObject) => void;
 }

--- a/src/game/objects/ship/ship.ts
+++ b/src/game/objects/ship/ship.ts
@@ -1,9 +1,11 @@
 import * as THREE from 'three';
-import { PolyObject } from './polyObject';
-import { MAX_RADIUS } from '../constants';
+import { PolyObject } from '../polyObject';
+import { MAX_RADIUS } from '../../constants';
+import { PolyHitbox } from '../hitbox';
 
 export class PolyShip implements PolyObject {
     public mesh: THREE.Object3D;
+    public hitbox: PolyHitbox;
 
     constructor() {
         const geometry = this.createGeometry();
@@ -15,7 +17,17 @@ export class PolyShip implements PolyObject {
 
         this.mesh = new THREE.Mesh(geometry, material);
         this.mesh.position.set(0, 0, MAX_RADIUS);
+
+        this.hitbox = new PolyHitbox(this.mesh, geometry);
     }
+
+    public update = () => {
+        this.hitbox.update();
+    };
+
+    public onCollide = (who: PolyObject): void => {
+        console.log('OH SHIT!');
+    };
 
     private createGeometry = (): THREE.BufferGeometry => {
         const geometry = new THREE.BufferGeometry();

--- a/src/game/objects/shots/manager.ts
+++ b/src/game/objects/shots/manager.ts
@@ -5,6 +5,7 @@ import { repeat, getDumpster, getOne, assertExists } from '../../utils';
 import { SHOTS_IN_SCENE } from '../../constants';
 import { Manager } from '../manager';
 import { ShotMeshFactory } from './meshFactory';
+import { PolyCollider, Groups } from '../../collider';
 
 export class ShotManager implements Manager<Shot> {
     private idleObjects: Set<Shot>;
@@ -12,7 +13,7 @@ export class ShotManager implements Manager<Shot> {
     private scene: PolyScene;
     private meshFactory: ShotMeshFactory;
 
-    constructor() {
+    constructor(private collider: PolyCollider) {
         this.idleObjects = new Set();
         this.liveObjects = new Set();
         this.scene = PolyScene.getInstance();
@@ -36,12 +37,16 @@ export class ShotManager implements Manager<Shot> {
         this.liveObjects.add(objectToSpawn);
 
         objectToSpawn.spawn(position);
+
+        this.collider.addObjectToGroup(objectToSpawn, Groups.shots);
     };
 
     public drop = (objectToDelete: Shot) => {
         objectToDelete.mesh.position.copy(getDumpster());
         this.liveObjects.delete(objectToDelete);
         this.idleObjects.add(objectToDelete);
+
+        this.collider.removeObjectFromGroup(objectToDelete, Groups.shots);
     };
 
     public update = () => {

--- a/src/game/objects/shots/meshFactory.ts
+++ b/src/game/objects/shots/meshFactory.ts
@@ -3,6 +3,7 @@ import { MeshFactory } from '../meshFactory';
 
 export class ShotMeshFactory implements MeshFactory {
     private mesh: THREE.Mesh;
+    private hitboxGeometry: THREE.Geometry | THREE.BufferGeometry;
 
     constructor() {
         const coreGeometry = new THREE.DodecahedronBufferGeometry(0.15);
@@ -13,17 +14,21 @@ export class ShotMeshFactory implements MeshFactory {
 
         const coreMesh = new THREE.Mesh(coreGeometry, coreMaterial);
 
-        const geometry = new THREE.DodecahedronBufferGeometry(0.3);
+        this.hitboxGeometry = new THREE.DodecahedronBufferGeometry(0.3);
         const material = new THREE.MeshBasicMaterial({
             color: 0xd68400,
             wireframe: true,
         });
 
-        this.mesh = new THREE.Mesh(geometry, material);
+        this.mesh = new THREE.Mesh(this.hitboxGeometry, material);
         this.mesh.add(coreMesh);
     }
 
     public buildMesh = (): THREE.Mesh => {
         return this.mesh.clone();
+    };
+
+    public getHitboxGeometry = (): THREE.Geometry | THREE.BufferGeometry => {
+        return this.hitboxGeometry.clone();
     };
 }

--- a/src/game/objects/shots/shot.ts
+++ b/src/game/objects/shots/shot.ts
@@ -5,15 +5,19 @@ import { PolyClock } from '../../clock/PolyClock';
 import { DropFunction } from '../manager';
 import { ShotMeshFactory } from './meshFactory';
 import { CENTER_RADIUS } from '../../constants';
+import { PolyHitbox } from '../hitbox';
 
 export class Shot implements PolyObject {
     public mesh: THREE.Object3D;
+    public hitbox: PolyHitbox;
+
     private drop: () => void;
     private speed: number;
     private clock: PolyClock;
 
     constructor(meshFactory: ShotMeshFactory, drop: DropFunction<Shot>) {
         this.mesh = meshFactory.buildMesh();
+        this.hitbox = new PolyHitbox(this.mesh, meshFactory.getHitboxGeometry());
 
         this.speed = 200;
         this.clock = PolyClock.getInstance();
@@ -24,12 +28,18 @@ export class Shot implements PolyObject {
         this.mesh.position.copy(position);
     };
 
+    public onCollide = (who: PolyObject): void => {
+        this.drop();
+    };
+
     public update = (): void => {
         const { delta } = this.clock;
 
         const currentLength = this.mesh.position.length();
         const lengthOffset = this.speed * delta;
         this.mesh.position.setLength(currentLength - lengthOffset);
+
+        this.hitbox.update();
 
         if (this.mesh.position.length() <= CENTER_RADIUS) {
             this.drop();

--- a/src/game/objects/stars/stars.ts
+++ b/src/game/objects/stars/stars.ts
@@ -1,9 +1,8 @@
 import * as THREE from 'three';
-import { repeat, MathUtils } from '../utils';
-import { CENTER_RADIUS } from '../constants';
-import { PolyObject } from './polyObject';
+import { repeat, MathUtils } from '../../utils';
+import { CENTER_RADIUS } from '../../constants';
 
-export class Stars implements PolyObject {
+export class Stars {
     public mesh: THREE.Group;
 
     constructor() {

--- a/src/game/polybius.ts
+++ b/src/game/polybius.ts
@@ -1,16 +1,17 @@
-import { Stars } from './objects/stars';
+import { Stars } from './objects/stars/stars';
 import { consoleInfo } from './utils';
 import { Center } from './objects/center';
 import { KeyboardControls } from './controls/keyboardControls';
 import { PolyClock } from './clock/PolyClock';
 import { ObjectController } from './controls/objectController';
-import { PolyShip } from './objects/ship';
+import { PolyShip } from './objects/ship/ship';
 import { FollowCamera } from './objects/followCamera';
 import { PolyRenderer } from './renderer';
 import { PolyScene } from './scene/PolyScene';
 import { AsteroidManager } from './objects/asteroid/manager';
 import { FollowMissileManager } from './objects/followMissile/manager';
 import { ShotManager } from './objects/shots/manager';
+import { PolyCollider, Groups } from './collider';
 
 export class Polybius {
     private renderer: PolyRenderer;
@@ -23,15 +24,26 @@ export class Polybius {
     private asteroids: AsteroidManager;
     private missiles: FollowMissileManager;
     private shots: ShotManager;
+    private collider: PolyCollider;
 
     constructor() {
         // Set up the scene
         this.scene = PolyScene.getInstance();
+
         // Set up the clock
         this.clock = PolyClock.getInstance();
 
+        // Set up the collider
+        this.collider = new PolyCollider();
+        this.collider.addRule(Groups.asteroids, Groups.ship);
+        this.collider.addRule(Groups.shots, Groups.asteroids);
+        this.collider.addRule(Groups.shots, Groups.center);
+        this.collider.addRule(Groups.shots, Groups.missiles);
+        this.collider.addRule(Groups.missiles, Groups.ship);
+
         // Set up the ship
         this.ship = new PolyShip();
+        this.collider.addObjectToGroup(this.ship, Groups.ship);
 
         // Set up camera
         this.camera = new FollowCamera(this.ship.mesh);
@@ -40,14 +52,16 @@ export class Polybius {
         this.renderer = new PolyRenderer(this.scene.scene, this.camera);
         this.renderer.resize();
 
+        // Set up various objects and managers
         const stars = new Stars();
         const center = new Center();
+        this.collider.addObjectToGroup(center, Groups.center);
 
         this.scene.add(this.ship.mesh, stars.mesh, center.mesh);
 
-        this.asteroids = new AsteroidManager();
-        this.missiles = new FollowMissileManager(this.ship.mesh);
-        this.shots = new ShotManager();
+        this.asteroids = new AsteroidManager(this.collider);
+        this.missiles = new FollowMissileManager(this.ship.mesh, this.collider);
+        this.shots = new ShotManager(this.collider);
 
         this.controls = new KeyboardControls();
         this.objectController = new ObjectController(this.controls, this.ship.mesh, this.shots);
@@ -66,6 +80,7 @@ export class Polybius {
         this.controls.dispose();
         this.asteroids.dispose();
         this.missiles.dispose();
+        this.scene.dispose();
         window.removeEventListener('resize', this.resize);
     };
 
@@ -85,12 +100,15 @@ export class Polybius {
         this.clock.tick();
 
         this.objectController.update();
-        this.camera.update();
+        this.ship.update();
 
         this.missiles.update();
         this.asteroids.update();
         this.shots.update();
 
+        this.collider.update();
+
+        this.camera.update();
         this.renderer.render();
     };
 }


### PR DESCRIPTION
Pretty big change. Adds a `Collider` to handle collisions.

The collider is based on rules.

A rule is a tuple `(group1, group2)` that means _"objects from group1 collide with objects from group2"_ (`collides` is a commutative relationship)

One can add objects to a specific group via the collider's `addObjectToGroup` and remove them with `removeObjectFromGroup`

PolyObject now accepts an optional `onCollide(who: PolyObject): void` to determine what to do on collisions.

In case `obj1` collides with `obj2` both `obj1.onCollide(obj2)` and `obj2.onCollide(obj1)` are called.
